### PR TITLE
Grid Search Bug

### DIFF
--- a/smsyn/inst/hires/pipeline.py
+++ b/smsyn/inst/hires/pipeline.py
@@ -85,8 +85,6 @@ def grid_search(pipe, debug=False):
         param_table.fe.isin([-1.0,-0.5,0,0.5])
     ].index
 
-    import pdb; pdb.set_trace()
-
     segments = pipe.segments
     if debug:
         idx_coarse = param_table[

--- a/smsyn/inst/hires/pipeline.py
+++ b/smsyn/inst/hires/pipeline.py
@@ -87,7 +87,6 @@ def grid_search(pipe, debug=False):
 
     segments = pipe.segments
     if debug:
-        import pdb; pdb.set_trace()
         idx_coarse = param_table[
             param_table.teff.isin([5500,6000]) &
             param_table.logg.isin([3.0,5.0]) &

--- a/smsyn/inst/hires/pipeline.py
+++ b/smsyn/inst/hires/pipeline.py
@@ -73,7 +73,7 @@ def grid_search(pipe, debug=False):
     """
 
     # Load up the model library
-    lib = smsyn.library.read_hdf(pipe.libfile, wavlim=[4000,4100])
+    lib = smsyn.library.read_hdf(pipe.libfile, wavlim=[4000, 4100])
     param_table = lib.model_table
     param_table['vsini'] = 5
     param_table['psf'] = 0
@@ -87,6 +87,7 @@ def grid_search(pipe, debug=False):
 
     segments = pipe.segments
     if debug:
+        import pdb; pdb.set_trace()
         idx_coarse = param_table[
             param_table.teff.isin([5500,6000]) &
             param_table.logg.isin([3.0,5.0]) &
@@ -96,8 +97,6 @@ def grid_search(pipe, debug=False):
 
     # Determine spacing of fine grid
     idx_fine = param_table[~param_table.fe.isin([0.2])].index
-
-    import pdb; pdb.set_trace()
 
     for segment in segments:
         spec = pipe._get_spec_segment(segment)

--- a/smsyn/inst/hires/pipeline.py
+++ b/smsyn/inst/hires/pipeline.py
@@ -101,13 +101,13 @@ def grid_search(pipe, debug=False):
         spec = pipe._get_spec_segment(segment)
         print "Grid search: {}".format(spec.__repr__())
 
-        param_table = smsyn.specmatch.grid_search(
+        param_table_out = smsyn.specmatch.grid_search(
             spec, pipe.libfile, pipe.wav_exclude, param_table, 
             idx_coarse, idx_fine
         )
 
         extname = 'grid_search_%i' % segment[0]
-        smsyn.io.fits.write_dataframe(pipe.smfile, extname, param_table,)
+        smsyn.io.fits.write_dataframe(pipe.smfile, extname, param_table_out)
 
 def lincomb(pipe):
     """

--- a/smsyn/inst/hires/pipeline.py
+++ b/smsyn/inst/hires/pipeline.py
@@ -97,6 +97,8 @@ def grid_search(pipe, debug=False):
     # Determine spacing of fine grid
     idx_fine = param_table[~param_table.fe.isin([0.2])].index
 
+    import pdb; pdb.set_trace()
+
     for segment in segments:
         spec = pipe._get_spec_segment(segment)
         print "Grid search: {}".format(spec.__repr__())

--- a/smsyn/inst/hires/pipeline.py
+++ b/smsyn/inst/hires/pipeline.py
@@ -85,6 +85,8 @@ def grid_search(pipe, debug=False):
         param_table.fe.isin([-1.0,-0.5,0,0.5])
     ].index
 
+    import pdb; pdb.set_trace()
+
     segments = pipe.segments
     if debug:
         idx_coarse = param_table[

--- a/smsyn/inst/hires/shift.py
+++ b/smsyn/inst/hires/shift.py
@@ -48,9 +48,4 @@ def shift(wav, flux, uflux, ref_wav, ref_flux):
     dvel = pvs.caculate_dvel(method=PIXVELSHIFT_METHOD)
     ech_shift = smsyn.echelle.shift_orders(ech, ref_wav, dvel)
     flux_shift, uflux_shift = smsyn.echelle.flatten(ech_shift)
-
-    if return_velocities:
-        return flux_shift, uflux_shift, dvel
-    else:
-        return flux_shift, uflux_shift
-
+    return flux_shift, uflux_shift

--- a/smsyn/inst/hires/shift.py
+++ b/smsyn/inst/hires/shift.py
@@ -3,7 +3,7 @@ NSEG = 8
 PIXVELSHIFT_METHOD = 'global'
 NPIX_CLIP = 20 # Number of pixels to clip off at the ends of orders.
 
-def shift(wav, flux, uflux, ref_wav, ref_flux):
+def shift(wav, flux, uflux, ref_wav, ref_flux, return_velocities=False):
     """Shift echelle spectrum to a reference spectrum
 
     Given an extracted echelle spectrum having `nord` orders and
@@ -33,6 +33,9 @@ def shift(wav, flux, uflux, ref_wav, ref_flux):
 
         ref_flux (array): Array with shape `(nref_wav, )` with the
             continuum-normalized flux of reference spectrum.
+
+        return_velocities (bool): return the velocity shift as well as the
+            shifted spectrum
 
     Returns:
         flux_shift (array): Array with shape `(nref_wav, )` target spectrum

--- a/smsyn/inst/hires/shift.py
+++ b/smsyn/inst/hires/shift.py
@@ -48,4 +48,9 @@ def shift(wav, flux, uflux, ref_wav, ref_flux):
     dvel = pvs.caculate_dvel(method=PIXVELSHIFT_METHOD)
     ech_shift = smsyn.echelle.shift_orders(ech, ref_wav, dvel)
     flux_shift, uflux_shift = smsyn.echelle.flatten(ech_shift)
-    return flux_shift, uflux_shift
+
+    if return_velocities:
+        return flux_shift, uflux_shift, dvel
+    else:
+        return flux_shift, uflux_shift
+

--- a/smsyn/inst/nres/shift.py
+++ b/smsyn/inst/nres/shift.py
@@ -38,6 +38,9 @@ def shift(wav, flux, uflux, ref_wav, ref_flux, return_velocities=False):
         ref_flux (array): Array with shape `(nref_wav, )` with the
             continuum-normalized flux of reference spectrum.
 
+        return_velocities (bool): return the velocity shift as well as the
+            shifted spectrum
+
     Returns:
         flux_shift (array): Array with shape `(nref_wav, )` target spectrum
             shifted to the reference wavelength scale.

--- a/smsyn/plotting/output.py
+++ b/smsyn/plotting/output.py
@@ -245,7 +245,7 @@ def bestfit(bestpars, pipe, title, method='polish', outfile='bestfit.pdf', *args
 
     pl.axvspan(absrv - absrv_err, absrv + absrv_err, color='0.8')
     pl.axvline(absrv, linestyle='dashed', color='0.5',
-               label=u"RV = {:.01f} ± {:.01f}".format(absrv, absrv_err))
+               label=u"RV = {:.01f} ± {:.01f} km/s".format(absrv, absrv_err))
 
     pl.legend(numpoints=2, loc='upper right', fontsize=12)
 

--- a/smsyn/specmatch.py
+++ b/smsyn/specmatch.py
@@ -40,12 +40,12 @@ def grid_search(spec, libfile, wav_exclude, param_table, idx_coarse, idx_fine):
     
     # First do a coarse grid search
     print "performing coarse grid search"
-    param_table_coarse = grid_search_loop(match, param_table.iloc[idx_coarse])
+    param_table_coarse = grid_search_loop(match, param_table.loc[idx_coarse, 'model_index'])
 
     # For the fine grid search, 
     print "performing fine grid search"
     top = param_table_coarse.sort_values(by='rchisq').head(10)
-    tab = param_table.iloc[idx_fine]
+    tab = param_table.loc[idx_fine, 'model_index']
     tab = tab.drop(idx_coarse)
 
     param_table_fine = tab[

--- a/smsyn/specmatch.py
+++ b/smsyn/specmatch.py
@@ -40,13 +40,13 @@ def grid_search(spec, libfile, wav_exclude, param_table, idx_coarse, idx_fine):
     
     # First do a coarse grid search
     print "performing coarse grid search"
-    import pdb; pdb.set_trace()
-    param_table_coarse = grid_search_loop(match, param_table.loc[idx_coarse, 'model_index'])
+    param_table_coarse = grid_search_loop(match, param_table.iloc[idx_coarse])
 
     # For the fine grid search, 
     print "performing fine grid search"
     top = param_table_coarse.sort_values(by='rchisq').head(10)
-    tab = param_table.loc[idx_fine, 'model_index']
+    import pdb; pdb.set_trace()
+    tab = param_table.iloc[idx_fine]
     tab = tab.drop(idx_coarse)
 
     param_table_fine = tab[

--- a/smsyn/specmatch.py
+++ b/smsyn/specmatch.py
@@ -40,6 +40,7 @@ def grid_search(spec, libfile, wav_exclude, param_table, idx_coarse, idx_fine):
     
     # First do a coarse grid search
     print "performing coarse grid search"
+    import pdb; pdb.set_trace()
     param_table_coarse = grid_search_loop(match, param_table.loc[idx_coarse, 'model_index'])
 
     # For the fine grid search, 

--- a/smsyn/specmatch.py
+++ b/smsyn/specmatch.py
@@ -40,12 +40,12 @@ def grid_search(spec, libfile, wav_exclude, param_table, idx_coarse, idx_fine):
     
     # First do a coarse grid search
     print "performing coarse grid search"
-    param_table_coarse = grid_search_loop(match, param_table.iloc[idx_coarse])
+    param_table_coarse = grid_search_loop(match, param_table.loc[idx_coarse])
 
     # For the fine grid search, 
     print "performing fine grid search"
     top = param_table_coarse.sort_values(by='rchisq').head(10)
-    tab = param_table.iloc[idx_fine]
+    tab = param_table.loc[idx_fine]
     tab = tab.drop(idx_coarse)
 
     param_table_fine = tab[
@@ -177,7 +177,7 @@ def lincomb(spec, libfile, wav_exclude, param_table):
     mw = np.array(mw)
     mw /= mw.sum()
 
-    params_out = lib.model_table.iloc[model_indecies]
+    params_out = lib.model_table.loc[model_indecies]
     params_out = params_out['teff logg fe'.split()]
     params_out = pd.DataFrame((params_out.T * mw).T.sum()).T
     params_out['vsini'] = out.params['vsini'].value

--- a/smsyn/specmatch.py
+++ b/smsyn/specmatch.py
@@ -40,7 +40,7 @@ def grid_search(spec, libfile, wav_exclude, param_table, idx_coarse, idx_fine):
     
     # First do a coarse grid search
     print "performing coarse grid search"
-    param_table_coarse = grid_search_loop(match, param_table.ix[idx_coarse])
+    param_table_coarse = grid_search_loop(match, param_table.iloc[idx_coarse])
 
     # For the fine grid search, 
     print "performing fine grid search"

--- a/smsyn/specmatch.py
+++ b/smsyn/specmatch.py
@@ -32,7 +32,7 @@ def grid_search(spec, libfile, wav_exclude, param_table, idx_coarse, idx_fine):
             search.
     """
     wavlim = spec.wav[0],spec.wav[-1]
-    lib = smsyn.library.read_hdf(libfile,wavlim=wavlim)
+    lib = smsyn.library.read_hdf(libfile, wavlim=wavlim)
     wavmask = wav_exclude_to_wavmask(spec.wav, wav_exclude)
     match = smsyn.match.Match(
         spec, lib, wavmask, cont_method='spline-dd', rot_method='rot'
@@ -40,6 +40,7 @@ def grid_search(spec, libfile, wav_exclude, param_table, idx_coarse, idx_fine):
     
     # First do a coarse grid search
     print "performing coarse grid search"
+    import pdb; pdb.set_trace()
     param_table_coarse = grid_search_loop(match, param_table.iloc[idx_coarse])
 
     # For the fine grid search, 

--- a/smsyn/specmatch.py
+++ b/smsyn/specmatch.py
@@ -40,7 +40,6 @@ def grid_search(spec, libfile, wav_exclude, param_table, idx_coarse, idx_fine):
     
     # First do a coarse grid search
     print "performing coarse grid search"
-    import pdb; pdb.set_trace()
     param_table_coarse = grid_search_loop(match, param_table.iloc[idx_coarse])
 
     # For the fine grid search, 

--- a/smsyn/specmatch.py
+++ b/smsyn/specmatch.py
@@ -44,7 +44,6 @@ def grid_search(spec, libfile, wav_exclude, param_table, idx_coarse, idx_fine):
     # For the fine grid search, 
     print "performing fine grid search"
     top = param_table_coarse.sort_values(by='rchisq').head(10)
-    import pdb; pdb.set_trace()
     tab = param_table.ix[idx_fine]
     tab = tab.drop(idx_coarse)
 

--- a/smsyn/specmatch.py
+++ b/smsyn/specmatch.py
@@ -45,7 +45,6 @@ def grid_search(spec, libfile, wav_exclude, param_table, idx_coarse, idx_fine):
     # For the fine grid search, 
     print "performing fine grid search"
     top = param_table_coarse.sort_values(by='rchisq').head(10)
-    import pdb; pdb.set_trace()
     tab = param_table.iloc[idx_fine]
     tab = tab.drop(idx_coarse)
 

--- a/smsyn/specmatch.py
+++ b/smsyn/specmatch.py
@@ -17,6 +17,7 @@ def wav_exclude_to_wavmask(wav, wav_exclude):
         wavmask[(wav_min < wav) & (wav < wav_max)] = True
     return wavmask
 
+
 def grid_search(spec, libfile, wav_exclude, param_table, idx_coarse, idx_fine):
     """
     Args:
@@ -44,7 +45,7 @@ def grid_search(spec, libfile, wav_exclude, param_table, idx_coarse, idx_fine):
     # For the fine grid search, 
     print "performing fine grid search"
     top = param_table_coarse.sort_values(by='rchisq').head(10)
-    tab = param_table.ix[idx_fine]
+    tab = param_table.iloc[idx_fine]
     tab = tab.drop(idx_coarse)
 
     param_table_fine = tab[
@@ -59,6 +60,7 @@ def grid_search(spec, libfile, wav_exclude, param_table, idx_coarse, idx_fine):
     print param_table[cols].sort_values(by='rchisq').head(10) 
 
     return param_table
+
 
 def grid_search_loop(match, param_table0):
     """Grid Search


### PR DESCRIPTION
@petigura check out this bug I found in `smsyn/inst/hires/pipeline.py`.

We loop over the segments doing a coarse and then fine grid search for each spectral segment. In the loop that is currently on the master branch we update the parameter table each time we do the search for a given segment. This means that the second segment has a different input parameter table. I'm not sure if this is what we meant to do (I doubt it), but regardless, the indices for the coarse and fine grids are not updated each time even though the length of the input parameter table has changed, so this was breaking the code (index out of bounds). I noticed this for NRES, but I'm not sure how (or if) it is working on Keck/APF data. Perhaps something changed with the way Pandas works and I'm only seeing this because I'm running Pandas 0.24.2.

I also switched from using `.ix` too `.iloc` in the immediate vicinity of where I was debugging because `.ix` is deprecated.